### PR TITLE
fix: update from next to ^5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/plugin-migration-v4-to-v5",
-  "version": "0.0.8",
+  "version": "1.0.0",
   "description": "Utility to help migrate Capacitor 4 plugins to Capacitor 5",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { rimraf } from 'rimraf';
 import { logger } from './log';
 import { run as runSubprocess } from './subprocess';
 
-const coreVersion = 'next';
+const coreVersion = '^5.0.0';
 const gradleVersion = '8.0.2';
 const AGPVersion = '8.0.0';
 const gmsVersion = '4.3.15';


### PR DESCRIPTION
This ensures the plugin is checking for dependencies of `^5.0.0` rather than `next`